### PR TITLE
Reorganize error handling

### DIFF
--- a/lib/getlocationdata.go
+++ b/lib/getlocationdata.go
@@ -1,9 +1,10 @@
 package whereami
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/joedborg/getexternalip"
+	"io"
 	"io/ioutil"
 	"net/http"
 )
@@ -14,8 +15,8 @@ type IPData struct {
 	Country     string
 	CountryCode string
 	Isp         string
-	Lat         string
-	Lon         string
+	Lat         float64
+	Lon         float64
 	Org         string
 	Query       string
 	Region      string
@@ -25,15 +26,38 @@ type IPData struct {
 	Zip         string
 }
 
+// GetLocationData returns the location data from ip-api.com
+// based on your external IP address.
 func GetLocationData() (IPData, error) {
-	ip, err := getexternalip.GetExternalIP()
-	url := fmt.Sprintf("http://ip-api.com/json/%s", ip)
+	var data IPData
+	ip, err := GetExternalIP()
+	if err != nil {
+		return data, err
+	}
+	url := "http://ip-api.com/json/" + ip
 	resp, err := http.Get(url)
+	if err != nil {
+		return data, fmt.Errorf("GET %q: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	var buf bytes.Buffer
+	dec := json.NewDecoder(io.TeeReader(resp.Body, &buf))
+	if err = dec.Decode(&data); err == nil {
+		return data, nil
+	}
+
+	return data, fmt.Errorf("Parse %q: %v", buf.String(), err)
+}
+
+// GetExternalIP returns your external IP address as returned by http://echoip.com.
+func GetExternalIP() (string, error) {
+	url := "http://echoip.com"
+	resp, err := http.Get(url)
+	if err != nil {
+		return "", fmt.Errorf("GET %q: %v", url, err)
+	}
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
-
-	var data IPData
-	err = json.Unmarshal(body, &data)
-
-	return data, err
+	return string(body), err
 }

--- a/whereami.go
+++ b/whereami.go
@@ -2,10 +2,15 @@ package main
 
 import (
 	"fmt"
+	"log"
+
 	"github.com/joedborg/whereami/lib"
 )
 
 func main() {
-	data, _ := whereami.GetLocationData()
+	data, err := whereami.GetLocationData()
+	if err != nil {
+		log.Fatalf("Error getting location: %v", err)
+	}
 	fmt.Printf("%s, %s\n", data.City, data.Country)
 }


### PR DESCRIPTION
Change IPData Lat, Lon to float64, to be parseable.

Return the response body if parsing fails.

And copy GetExternalIP from
github.com/joedborg/getexternalip/getexternalip as it swallows its
errors, and may panic (if http.Get fails, resp can be nil).
